### PR TITLE
Dline

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/DecoratedLine.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/DecoratedLine.java
@@ -1,0 +1,48 @@
+package com.ait.lienzo.client.core.shape;
+
+import com.ait.lienzo.client.core.Context2D;
+import com.ait.lienzo.client.core.types.NFastArrayList;
+import com.ait.lienzo.client.core.types.PathPartList;
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.client.core.types.Point2DArray;
+
+public class DecoratedLine extends Group
+{
+    private AbstractOffsetMultiPointShape line;
+
+    public DecoratedLine(AbstractOffsetMultiPointShape line, SimpleArrow tailArrow, SimpleArrow headArrow) {
+        add(line);
+        add(tailArrow);
+        add(headArrow);
+    }
+
+    protected void drawWithoutTransforms(final Context2D context, double alpha)
+    {
+        if ((context.isSelection()) && (false == isListening()))
+        {
+            return;
+        }
+        alpha = alpha * getAttributes().getAlpha();
+
+        if (alpha <= 0)
+        {
+            return;
+        }
+
+        NFastArrayList shapes = getChildNodes();
+
+        AbstractOffsetMultiPointShape line = (AbstractOffsetMultiPointShape) shapes.get(0);
+        line.drawWithoutTransforms(context, alpha);
+        Point2DArray points = line.getPoint2DArray();
+        setX( 0 );
+        setY( 0 );
+
+        SimpleArrow tailArrow = (SimpleArrow) shapes.get(1);
+        tailArrow.setPoints(new Point2DArray(points.get(0), line.getTailOffsetPoint()));
+        tailArrow.drawWithoutTransforms(context, alpha);
+
+        SimpleArrow headArrow = (SimpleArrow) shapes.get(2);
+        headArrow.setPoints(new Point2DArray(points.get(points.size() -1), line.getHeadOffsetPoint()));
+        headArrow.drawWithoutTransforms(context, alpha);
+    }
+}

--- a/src/main/java/com/ait/lienzo/client/core/shape/SimpleArrow.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/SimpleArrow.java
@@ -1,0 +1,120 @@
+package com.ait.lienzo.client.core.shape;
+
+import com.ait.lienzo.client.core.Context2D;
+import com.ait.lienzo.client.core.shape.json.IFactory;
+import com.ait.lienzo.client.core.types.BoundingBox;
+import com.ait.lienzo.client.core.types.PathPartList;
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.client.core.types.Point2DArray;
+import com.ait.lienzo.shared.core.types.ShapeType;
+
+public class SimpleArrow extends Shape<SimpleArrow>
+{
+    private final PathPartList m_list = new PathPartList();
+
+
+    public SimpleArrow()
+    {
+        super(ShapeType.ARROW);
+    }
+
+    public SimpleArrow(Point2D start, Point2D end)
+    {
+        super(ShapeType.ARROW);
+        setPoints(new Point2DArray(start, end));
+    }
+
+    @Override public BoundingBox getBoundingBox()
+    {
+        return null;
+    }
+
+    @Override protected boolean prepare(Context2D context, Attributes attr, double alpha)
+    {
+        if (m_list.size() < 1)
+        {
+            Point2DArray points = attr.getPoints();
+            buildArrow0(points.get(0), points.get(1), m_list);
+        }
+        if (m_list.size() < 1)
+        {
+            return false;
+        }
+        context.path(m_list);
+
+        return true;
+    }
+
+    private void buildArrow0(Point2D tip, Point2D base, PathPartList list)
+    {
+        Point2D dv = base.sub(tip);
+        double length = dv.getLength();
+        Point2D dx = dv.unit(); // unit vector in the direction of SE
+        Point2D dy = dx.perpendicular();
+
+        Point2D p0 = tip;
+        double  halfWidth = (length*0.75)/2; // TODO The 0.75 could be an attribute (mdp)
+        Point2D p1 = base.add(dy.mul(halfWidth));
+        Point2D p2 = base.sub(dy.mul(halfWidth));
+
+        m_list.M(p0);
+        m_list.L(p1);
+        m_list.L(p2);
+        m_list.L(p0);
+        m_list.close();
+    }
+
+    private void block0(Point2D tip, Point2D base, PathPartList list)
+    {
+        Point2D dv = base.sub(tip);
+        double length = dv.getLength();
+
+        Point2D dx = dv.unit(); // unit vector in the direction of SE
+        Point2D dy = dx.perpendicular();
+
+        Point2D p0 = tip;
+        double  halfWidth = length/2;
+        Point2D p1 = tip.add(dy.mul(halfWidth));
+        Point2D p2 = tip.sub(dy.mul(halfWidth));
+        Point2D p3 = base.add(dy.mul(halfWidth));
+        Point2D p4 = base.sub(dy.mul(halfWidth));
+
+        m_list.M(p1);
+        m_list.L(p2);
+        m_list.L(p4);
+        m_list.L(p3);
+        m_list.L(p1);
+        m_list.close();
+    }
+
+    private void circle0(Point2D tip, Point2D base, PathPartList list)
+    {
+        Point2D dv = base.sub(tip);
+        double length = dv.getLength();
+
+        double  r = length/2;
+        m_list.M(tip);
+        m_list.A(r, r, 0, 1, 0, base.getX(), base.getY());
+        m_list.A(r, r, 0, 1, 0, tip.getX(), tip.getY());
+        m_list.close();
+    }
+
+
+    @Override public IFactory<SimpleArrow> getFactory()
+    {
+        return null;
+    }
+
+
+    public Point2DArray getPoints()
+    {
+        return getAttributes().getPoints();
+    }
+
+    public SimpleArrow setPoints(Point2DArray points)
+    {
+        getAttributes().setPoints(points);
+
+        return this;
+    }
+}

--- a/src/main/java/com/ait/lienzo/client/core/types/NFastDoubleArrayJSO.java
+++ b/src/main/java/com/ait/lienzo/client/core/types/NFastDoubleArrayJSO.java
@@ -71,6 +71,11 @@ public class NFastDoubleArrayJSO extends NBaseNativeArrayJSO<NFastDoubleArrayJSO
         return this[indx];
     }-*/;
 
+    public final native void set(int indx, double value)
+    /*-{
+        this[indx] = value;
+    }-*/;
+
     public final native double pop()
     /*-{
         return this.pop();


### PR DESCRIPTION
Offsets for PolyLine now work. I've improved the offsets for OrthogonalPolyline too. 

One potential point of improvement is PolyLine and OrhtogonalPolyline have two methods with same logic - correctTailWithOffset and correctHeadWithOffset. However one works with Point2DArray an the other NFastDoubleArrayJSO. 

I believe this line clones the points:
list = list.noAdjacentPoints();

If it returned a NFastDoubleArrayJSO and PolyLine used that instead - we could unify how the two work, and share the same static method.