### PR TITLE
Initial Group handling for wires stuff

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/GroupOf.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/GroupOf.java
@@ -41,6 +41,7 @@ import com.ait.lienzo.shared.core.types.DragConstraint;
 import com.ait.lienzo.shared.core.types.DragMode;
 import com.ait.lienzo.shared.core.types.GroupType;
 import com.ait.lienzo.shared.core.types.NodeType;
+import com.ait.tooling.common.api.java.util.UUID;
 import com.ait.tooling.common.api.java.util.function.Predicate;
 import com.ait.tooling.nativetools.client.collection.NFastArrayList;
 import com.google.gwt.json.client.JSONArray;
@@ -57,6 +58,8 @@ public abstract class GroupOf<T extends IPrimitive<?>, C extends GroupOf<T, C>> 
     private IControlHandleFactory  m_controlHandleFactory   = null;
 
     private DragConstraintEnforcer m_dragConstraintEnforcer = null;
+
+    private String           m_uuid;
 
     /**
      * Constructor. Creates an instance of a group.
@@ -76,6 +79,15 @@ public abstract class GroupOf<T extends IPrimitive<?>, C extends GroupOf<T, C>> 
         super(NodeType.GROUP, node, ctx);
 
         m_type = type;
+    }
+
+    public String uuid()
+    {
+        if (null == m_uuid)
+        {
+            m_uuid = UUID.uuid();
+        }
+        return m_uuid;
     }
 
     /**

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/Connection.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/Connection.java
@@ -110,6 +110,10 @@ public class Connection extends AbstractControlHandle
         {
             magnet.addHandle(this);
 
+            IPrimitive control = magnet.getControl();
+
+            move(control.getX(), control.getY());
+
             if (m_end == ArrowEnd.TAIL)
             {
                 m_line.setTailDirection(magnet.getDirection());

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/IMagnets.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/IMagnets.java
@@ -17,6 +17,7 @@
 
 package com.ait.lienzo.client.core.shape.wires;
 
+import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.Shape;
 
 public interface IMagnets
@@ -36,4 +37,6 @@ public interface IMagnets
     int size();
 
     Shape<?> getShape();
+
+    Group getGroup();
 }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/Magnet.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/Magnet.java
@@ -130,7 +130,6 @@ public class Magnet extends AbstractControlHandle implements Iterable<Connection
             }
         }
 
-        connection.move(m_control.getX(), m_control.getY());
         return this;
     }
 


### PR DESCRIPTION
-Magnets can now target a Group, but it still needs a path (that is inside of the group).  The main difference is whether the handlers are added to the group or the shape.
-AlignAndDistribute can now also take Shapes or Groups. Until we refactor the shared methods to the same interface, I use an interface abstract the Shape vs Group casting. It has no triggers to handle group add/remove operations, to keep things updated.