### PR TITLE
prevent NPE when dragging WiresShape

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresShapeDragHandler.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresShapeDragHandler.java
@@ -90,7 +90,9 @@ public class WiresShapeDragHandler implements NodeMouseDownHandler, NodeMouseUpH
                 ((WiresShape) m_parent).getPath().setAlpha(m_priorAlpha);
                 batch = true;
             }
-            if (parent != null && parent instanceof WiresShape && parent.getContainmentAcceptor().containmentAllowed(parent, m_shape))
+            if (parent != null && parent instanceof WiresShape
+                    && parent.getContainmentAcceptor() != null
+                    && parent.getContainmentAcceptor().containmentAllowed(parent, m_shape))
             {
                 highlightContainer((WiresShape) parent);
                 batch = true;


### PR DESCRIPTION
for shapes that are non-containing (`setContainerAdaptor(null)`)