### PR TITLE
Reset flag and related variables when WiresContainer body restored during drag operation

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresDockingAndContainmentControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresDockingAndContainmentControlImpl.java
@@ -255,6 +255,11 @@ public class WiresDockingAndContainmentControlImpl implements WiresDockingAndCon
                 ((WiresShape) m_parent).getPath().setFillGradient((RadialGradient) m_priorFillGradient);
             }
             ((WiresShape) m_parent).getPath().setFillAlpha(m_priorAlpha);
+
+            m_priorFillChanged = false;
+            m_priorFill = null;
+            m_priorFillGradient = null;
+            m_priorAlpha = 0.0;
         }
     }
 


### PR DESCRIPTION
During drag operations a ```WiresContainer``` could have it's body restored to that of a previous ```parent```.