### PR TITLE
Allow additional paths to be added to ColorMapBackedPicker for a WiresShape

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Maven:
 <dependency>
   <groupId>com.ahome-it</groupId>
   <artifactId>lienzo-core</artifactId>
-  <version>2.0.284-RELEASE</version>
+  <version>2.0.285-SNAPSHOT</version>
 </dependency>
 ```
 Gradle:
 ```
 dependencies {
-    compile(group:'com.ahome-it',name:'lienzo-core',version:'2.0.284-RELEASE')
+    compile(group:'com.ahome-it',name:'lienzo-core',version:'2.0.285-SNAPSHOT')
 }
 ```
 Javadoc URL:

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ sourceCompatibility = 1.7
 
 targetCompatibility = 1.7
 
-version = '2.0.284-RELEASE'
+version = '2.0.285-SNAPSHOT'
 
 group = 'com.ahome-it'
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.ahome-it</groupId>
 	<artifactId>lienzo-core</artifactId>
-	<version>2.0.284-RELEASE</version>
+	<version>2.0.285-SNAPSHOT</version>
 	<dependencies>
 		<dependency>
 			<groupId>com.ahome-it</groupId>

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/BackingColorMapUtils.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/BackingColorMapUtils.java
@@ -73,7 +73,11 @@ public class BackingColorMapUtils
 
     public static void drawShapeToBacking(Context2D ctx, WiresShape shape, String color, double strokeWidth, boolean fill)
     {
-        MultiPath multiPath = shape.getPath();
+        drawShapeToBacking(ctx, shape.getPath(), color, strokeWidth, fill);
+    }
+
+    public static void drawShapeToBacking(Context2D ctx, MultiPath multiPath, String color, double strokeWidth, boolean fill)
+    {
         NFastArrayList<PathPartList> listOfPaths = multiPath.getPathPartListArray();
 
         for (int k = 0; k < listOfPaths.size(); k++)

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresDockingAndContainmentControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresDockingAndContainmentControlImpl.java
@@ -17,11 +17,23 @@
 package com.ait.lienzo.client.core.shape.wires.handlers.impl;
 
 import com.ait.lienzo.client.core.shape.MultiPath;
-import com.ait.lienzo.client.core.shape.wires.*;
+import com.ait.lienzo.client.core.shape.wires.PickerPart;
+import com.ait.lienzo.client.core.shape.wires.WiresContainer;
+import com.ait.lienzo.client.core.shape.wires.WiresLayer;
+import com.ait.lienzo.client.core.shape.wires.WiresManager;
+import com.ait.lienzo.client.core.shape.wires.WiresShape;
+import com.ait.lienzo.client.core.shape.wires.WiresUtils;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresDockingAndContainmentControl;
 import com.ait.lienzo.client.core.shape.wires.picker.ColorMapBackedPicker;
-import com.ait.lienzo.client.core.types.*;
+import com.ait.lienzo.client.core.types.BoundingBox;
+import com.ait.lienzo.client.core.types.FillGradient;
+import com.ait.lienzo.client.core.types.LinearGradient;
+import com.ait.lienzo.client.core.types.PatternGradient;
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.client.core.types.RadialGradient;
 import com.ait.lienzo.client.core.util.Geometry;
+import com.ait.lienzo.client.core.util.ScratchPad;
+import com.ait.tooling.nativetools.client.collection.NFastArrayList;
 
 /**
  * This class handles parent and child docking snap. For each potential parent it generates a picker image. This image consists of three layers
@@ -91,6 +103,18 @@ public class WiresDockingAndContainmentControlImpl implements WiresDockingAndCon
         return m_picker;
     }
 
+    protected ColorMapBackedPicker makeColorMapBackedPicker(NFastArrayList<WiresShape> children,
+                                                            ScratchPad scratchPad,
+                                                            WiresShape shape,
+                                                            boolean isDockingAllowed,
+                                                            int hotSpotSize)
+    {
+        return new ColorMapBackedPicker(children,
+                                        scratchPad,
+                                        shape,
+                                        isDockingAllowed,
+                                        hotSpotSize);
+    }
 
     @Override
     public void dragStart( final Context context ) {
@@ -109,11 +133,12 @@ public class WiresDockingAndContainmentControlImpl implements WiresDockingAndCon
 
         m_parent = m_shape.getParent();
 
-        m_picker = new ColorMapBackedPicker( m_layer.getChildShapes(),
-                                             m_layer.getLayer().getScratchPad(),
-                                             m_shape,
-                                             m_shape.getDockingAcceptor().dockingAllowed( m_parent, m_shape ),
-                                             m_shape.getDockingAcceptor().getHotspotSize() );
+        m_picker = makeColorMapBackedPicker(m_layer.getChildShapes(),
+                                            m_layer.getLayer().getScratchPad(),
+                                            m_shape,
+                                            m_shape.getDockingAcceptor().dockingAllowed(m_parent,
+                                                                                        m_shape),
+                                            m_shape.getDockingAcceptor().getHotspotSize());
 
         if (m_parent != null && m_parent instanceof WiresShape)
         {
@@ -366,4 +391,5 @@ public class WiresDockingAndContainmentControlImpl implements WiresDockingAndCon
         m_priorFillGradient = null;
         m_picker = null;
     }
+
 }


### PR DESCRIPTION
The ```ColorMapBackedPicker``` normally only renders ```WiresShapes``` ```MultiPath``` however I need ```WiresShapes``` to potentially have a different "drop target" to the Shape itself. For example the Shape is a column header and can be dragged, but I want cells to be dropped into the column and not the column header. If I drag a cell I do not want the column to move.

This PR allows me to add additional information to the colour-map used to determine "drop targets".

Also Notionally move to 2.0.285-SNAPSHOT to simplify making successive changes.

@SprocketNYC Hi Dean, I'm still not clear on lienzo's release process; but this PR moves the 2.0 branch to a SNAPSHOT version (which might make no sense at all outside the world of Maven). What do you normally do when you have lots of small commits being made and you don't want to release a revision for each commit?

@romartin FYI