### PR TITLE
Wires bug fixings & potential release

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresShape.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresShape.java
@@ -322,7 +322,10 @@ public class WiresShape extends WiresContainer
         @Override
         public void onNodeDragEnd(NodeDragEndEvent event)
         {
-            this.shapeControl.dragEnd(new WiresDragControlContext(event.getX(), event.getY(), event.getSource()));
+            final boolean accepts = this.shapeControl.dragEnd(new WiresDragControlContext(event.getX(), event.getY(), event.getSource()));
+            if (!accepts) {
+                event.getDragContext().reset();
+            }
         }
 
         @Override

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresShapeControlHandleList.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresShapeControlHandleList.java
@@ -424,19 +424,17 @@ public class WiresShapeControlHandleList implements IControlHandleList
             return;
         }
 
-        for (WiresShape shape : m_wires_shape.getChildShapes())
+        // For usability goals let's ensure children shape's controls are hidden as
+        // with the parent one.
+        if (!visible)
         {
-            if (shape.getControls() == null)
+            for (WiresShape shape : m_wires_shape.getChildShapes())
             {
-                continue;
-            }
+                if (shape.getControls() == null)
+                {
+                    continue;
+                }
 
-            if (visible)
-            {
-                shape.getControls().show();
-            }
-            else
-            {
                 shape.getControls().hide();
             }
         }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/HasDragControl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/HasDragControl.java
@@ -18,7 +18,7 @@ public interface HasDragControl {
 
     void dragMove( Context context );
 
-    void dragEnd( Context context );
+    boolean dragEnd( Context context );
 
     boolean dragAdjust( Point2D dxy );
 }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectionControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectionControlImpl.java
@@ -79,7 +79,7 @@ public class WiresConnectionControlImpl implements WiresConnectionControl
     }
 
     @Override
-    public void dragEnd( final Context context ) {
+    public boolean dragEnd( final Context context ) {
         if (m_magnets != null)
         {
             m_magnets.hide();
@@ -91,6 +91,7 @@ public class WiresConnectionControlImpl implements WiresConnectionControl
         m_colorKey = null;
         m_shape_color_map.clear();
         m_magnet_color_map.clear();
+        return true;
     }
 
     @Override

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectorControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectorControlImpl.java
@@ -77,7 +77,7 @@ public class WiresConnectorControlImpl implements WiresConnectorControl {
     }
 
     @Override
-    public void dragEnd( final Context context ) {
+    public boolean dragEnd( final Context context ) {
 
         m_connector.getGroup().setX( 0 ).setY( 0 );
 
@@ -101,6 +101,7 @@ public class WiresConnectorControlImpl implements WiresConnectorControl {
 
         m_startPoints = null;
 
+        return true;
     }
 
     @Override

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresDockingAndContainmentControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresDockingAndContainmentControlImpl.java
@@ -149,8 +149,8 @@ public class WiresDockingAndContainmentControlImpl implements WiresDockingAndCon
     }
 
     @Override
-    public void dragEnd( final Context context ) {
-        addShapeToParent();
+    public boolean dragEnd( final Context context ) {
+        return addShapeToParent();
     }
 
     @Override
@@ -229,6 +229,11 @@ public class WiresDockingAndContainmentControlImpl implements WiresDockingAndCon
                     parentPart = null;
                 }
                 batch = true;
+            } else {
+                // The parent is the layer itself.
+                // Fire the containment acceptor allow evaluation. No visual
+                // If containment not allowed, no feedback by default.
+                m_layer.getContainmentAcceptor().containmentAllowed(m_layer, m_shape);
             }
 
             if (batch)
@@ -321,7 +326,7 @@ public class WiresDockingAndContainmentControlImpl implements WiresDockingAndCon
         }
     }
 
-    protected void addShapeToParent()
+    protected boolean addShapeToParent()
     {
         Point2D absLoc = WiresUtils.getLocation( m_shape.getGroup() );
 
@@ -335,6 +340,8 @@ public class WiresDockingAndContainmentControlImpl implements WiresDockingAndCon
             m_path.removeFromParent();
             m_layer.getLayer().getOverLayer().batch();
         }
+
+        boolean accepted = true;
 
         if (m_parentPart == null || m_parentPart.getShapePart() == PickerPart.ShapePart.BODY)
         {
@@ -361,6 +368,10 @@ public class WiresDockingAndContainmentControlImpl implements WiresDockingAndCon
 
                 m_layer.getLayer().batch();
             }
+            else
+            {
+                accepted = false;
+            }
         }
         else if (m_parentPart != null && m_parentPart.getShapePart() != PickerPart.ShapePart.BODY && m_parent.getDockingAcceptor().acceptDocking(m_parent, m_shape))
         {
@@ -385,6 +396,7 @@ public class WiresDockingAndContainmentControlImpl implements WiresDockingAndCon
         m_priorFillChanged = false;
         m_priorFillGradient = null;
         m_picker = null;
+        return accepted;
     }
 
     protected ColorMapBackedPicker makeColorMapBackedPicker(final NFastArrayList<WiresShape> children,

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
@@ -86,12 +86,13 @@ public class WiresShapeControlImpl implements WiresShapeControl
     }
 
     @Override
-    public void dragEnd(final Context context)
+    public boolean dragEnd(final Context context)
     {
+        boolean result = true;
 
         if (m_dockingAndContainmentControl != null)
         {
-            m_dockingAndContainmentControl.dragEnd(context);
+           result = m_dockingAndContainmentControl.dragEnd(context);
         }
 
         if (m_alignAndDistributeHandler != null)
@@ -99,6 +100,7 @@ public class WiresShapeControlImpl implements WiresShapeControl
             m_alignAndDistributeHandler.dragEnd();
         }
 
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Hey @manstis @hasys @SprocketNYC !

Here are a couple of bug fixes for wires stuff, I have been testing and it seems not to broke existing code - I say this because would be nice having a release with these latest commits included as for our's Friday release, just if possible. 
These are the two fixes on this PR:
- Reset drag context if any of the acceptor's allow/accept calls fail.
- If a wires shape contains shildren, do not show magnets as within the parent ones. 

@manstis @hasys you're up to date with this.. anyway agree? :) 
@SprocketNYC Hey Dean, you think could be possible to merge this and do a release (I think would be the `2.0.285-RELEASE`) for 2.0 branch, please?

Thanks in advance!!
Roger