### PR TITLE
Added core attributes to improve the selection on the context.

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/Attribute.java
+++ b/src/main/java/com/ait/lienzo/client/core/Attribute.java
@@ -77,6 +77,10 @@ public class Attribute
 
     public static final Attribute           FILL_BOUNDS_FOR_SELECTION        = new Attribute("fillBoundsForSelection", MESSAGES.fillBoundsForSelectionLabel(), MESSAGES.fillBoundsForSelectionDescription(), AttributeType.BOOLEAN_TYPE);
 
+    public static final Attribute           SELECTION_BOUNDS_OFFSET          = new Attribute("selectionBoundsOffset", MESSAGES.selectionBoundsOffsetLabel(), MESSAGES.selectionBoundsOffsetDescription(), AttributeType.NUMBER_TYPE);
+
+    public static final Attribute           SELECTION_STROKE_OFFSET          = new Attribute("selectionStrokeOffset", MESSAGES.selectionStrokeOffsetLabel(), MESSAGES.selectionStrokeOffsetDescription(), AttributeType.NUMBER_TYPE);
+
     public static final Attribute           DRAG_CONSTRAINT                  = new Attribute("dragConstraint", MESSAGES.dragConstraintLabel(), MESSAGES.dragConstraintDescription(), AttributeType.DRAG_CONSTRAINT_TYPE);
 
     public static final Attribute           DRAG_BOUNDS                      = new Attribute("dragBounds", MESSAGES.dragBoundsLabel(), MESSAGES.dragBoundsDescription(), AttributeType.DRAG_BOUNDS_TYPE);

--- a/src/main/java/com/ait/lienzo/client/core/i18n/MessageConstants.java
+++ b/src/main/java/com/ait/lienzo/client/core/i18n/MessageConstants.java
@@ -483,6 +483,18 @@ public interface MessageConstants extends Constants
     @DefaultStringValue("If a shape's bounding box should be filled for events on the selection layer.")
     public String fillBoundsForSelectionDescription();
 
+    @DefaultStringValue("The pixels that will be used to increase the bounding box size on the selection layer.")
+    public String selectionBoundsOffsetLabel();
+
+    @DefaultStringValue("The pixels that will be used to increase the bounding box size on the selection layer.")
+    public String selectionBoundsOffsetDescription();
+
+    @DefaultStringValue("The pixels that will be used to increase the stroke wdith on the selection layer.")
+    public String selectionStrokeOffsetLabel();
+
+    @DefaultStringValue("The pixels that will be used to increase the bounding box on the selection layer.")
+    public String selectionStrokeOffsetDescription();
+
     @DefaultStringValue("Transformable")
     public String transformableLabel();
 

--- a/src/main/java/com/ait/lienzo/client/core/shape/Attributes.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/Attributes.java
@@ -487,6 +487,34 @@ public class Attributes
         return false;
     }
 
+    public final void setSelectionBoundsOffset(final double offset)
+    {
+        put(Attribute.SELECTION_BOUNDS_OFFSET.getProperty(), offset);
+    }
+
+    public final double getSelectionBoundsOffset()
+    {
+        if (isDefined(Attribute.SELECTION_BOUNDS_OFFSET))
+        {
+            return getDouble(Attribute.SELECTION_BOUNDS_OFFSET.getProperty());
+        }
+        return 0d;
+    }
+
+    public final void setSelectionStrokeOffset(final double offset)
+    {
+        put(Attribute.SELECTION_STROKE_OFFSET.getProperty(), offset);
+    }
+
+    public final double getSelectionStrokeOffset()
+    {
+        if (isDefined(Attribute.SELECTION_STROKE_OFFSET))
+        {
+            return getDouble(Attribute.SELECTION_STROKE_OFFSET.getProperty());
+        }
+        return 0d;
+    }
+
     public final void setListening(final boolean listening)
     {
         put(Attribute.LISTENING.getProperty(), listening);

--- a/src/main/java/com/ait/lienzo/client/core/shape/Shape.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/Shape.java
@@ -398,12 +398,16 @@ public abstract class Shape <T extends Shape<T>> extends Node<T>implements IPrim
                         if (wide > 0)
                         {
                             final double high = bbox.getHeight();
+                            final double offset = getSelectionBoundsOffset();
 
                             if (high > 0)
                             {
                                 context.setFillColor(color);
 
-                                context.fillRect(bbox.getX(), bbox.getY(), wide, high);
+                                context.fillRect(bbox.getX() - offset,
+                                                 bbox.getY() - offset,
+                                                 wide + offset,
+                                                 high + offset);
                             }
                         }
                     }
@@ -553,6 +557,8 @@ public abstract class Shape <T extends Shape<T>> extends Node<T>implements IPrim
         {
             return false;
         }
+
+        double strokeOffset = 0;
         if (context.isSelection())
         {
             color = getColorKey();
@@ -562,6 +568,8 @@ public abstract class Shape <T extends Shape<T>> extends Node<T>implements IPrim
                 return false;
             }
             context.save();
+
+            strokeOffset = getSelectionStrokeOffset();
         }
         else
         {
@@ -571,7 +579,7 @@ public abstract class Shape <T extends Shape<T>> extends Node<T>implements IPrim
         }
         context.setStrokeColor(color);
 
-        context.setStrokeWidth(width);
+        context.setStrokeWidth(width + strokeOffset);
 
         if (false == attr.hasExtraStrokeAttributes())
         {
@@ -1057,6 +1065,45 @@ public abstract class Shape <T extends Shape<T>> extends Node<T>implements IPrim
         getAttributes().setFillBoundsForSelection(selection);
 
         return cast();
+    }
+
+    /**
+     * Sets the number of pixels that are used to increase
+     * the bounding box on the selection layer.
+     */
+    public final T setSelectionBoundsOffset(final double offset)
+    {
+        getAttributes().setSelectionBoundsOffset(offset);
+
+        return cast();
+    }
+
+    /**
+     * Gets the number of pixels that are used to increase
+     * the bounding box on the selection layer.
+     */
+    public final double getSelectionBoundsOffset()
+    {
+        return getAttributes().getSelectionBoundsOffset();
+    }
+
+    /**
+     * Sets the number of pixels that are used to increase
+     * stroke size on the selection layer.
+     */
+    public final T setSelectionStrokeOffset(final double offset)
+    {
+        getAttributes().setSelectionStrokeOffset(offset);
+
+        return cast();
+    }
+
+    /**
+     * Gets the number of pixels that are used to increase
+     * stroke size on the selection layer.
+     */
+    public final double getSelectionStrokeOffset() {
+        return getAttributes().getSelectionStrokeOffset();
     }
 
     /**
@@ -1769,6 +1816,10 @@ public abstract class Shape <T extends Shape<T>> extends Node<T>implements IPrim
             addAttribute(Attribute.FILL_SHAPE_FOR_SELECTION);
 
             addAttribute(Attribute.FILL_BOUNDS_FOR_SELECTION);
+
+            addAttribute(Attribute.SELECTION_BOUNDS_OFFSET);
+
+            addAttribute(Attribute.SELECTION_STROKE_OFFSET);
 
             addAttribute(Attribute.EVENT_PROPAGATION_MODE);
         }


### PR DESCRIPTION
Hey @SprocketNYC , @mdproctor @hasys 

As commented before, this is about adding a couple of core attributes to allow improving the selection for different shapes. So added an offset attribute related to both the stroke width and for the bounding box size, only being used on the selection layer. Really simple and a great quick win! xD

Thanks!