### PR TITLE
[JBPM-5544] Added basic text wrapping

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/Text.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/Text.java
@@ -172,14 +172,15 @@ public class Text extends Shape<Text>
         double width = wrapBoundaries.getWidth();
         int numOfLines = 1;
         String[] words = getText().split(" ");
-        String nextLine = words[0];
+        StringBuilder nextLine = new StringBuilder(words[0]);
         for (int i = 1; i < words.length; i++) {
-            if (getBoundingBoxForString(nextLine + words[i]).getWidth() <= wrapBoundaries.getWidth())
+            if (getBoundingBoxForString(nextLine + " " + words[i]).getWidth() <= wrapBoundaries.getWidth())
             {
-                nextLine = nextLine + " " + words[i];
+                nextLine.append(" ").append(words[i]);
             }
             else {
-                nextLine = words[i];
+                nextLine.setLength(words[i].length());
+                nextLine.replace(0,words[i].length(),words[i]);
                 numOfLines++;
             }
         }
@@ -525,21 +526,20 @@ public class Text extends Shape<Text>
     {
         if (null != wrapBoundaries) {
             String[] words = attr.getText().split(" ");
-            String nextLine = words[0];
-            int numOfLines = 1;
+            StringBuilder nextLine = new StringBuilder(words[0]);
             ArrayList<String> lines = new ArrayList<>();
             for (int i = 1; i < words.length; i++) {
-                if (getBoundingBoxForString(nextLine + words[i]).getWidth() <= wrapBoundaries.getWidth())
+                if (getBoundingBoxForString(nextLine + " " + words[i]).getWidth() <= wrapBoundaries.getWidth())
                 {
-                    nextLine = nextLine + " " + words[i];
+                    nextLine.append(" ").append(words[i]);
                 }
                 else {
-                    lines.add(nextLine);
-                    nextLine = words[i];
-                    numOfLines++;
+                    lines.add(nextLine.toString());
+                    nextLine.setLength(words[i].length());
+                    nextLine.replace(0,words[i].length(),words[i]);
                 }
             }
-            lines.add(nextLine);
+            lines.add(nextLine.toString());
 
             double xOffset = 0;
 
@@ -666,7 +666,7 @@ public class Text extends Shape<Text>
      * @param context
      * @return TextMetric or null if the text is empty or null
      */
-    private double getLineHeight(final Context2D context)
+    public double getLineHeight(final Context2D context)
     {
         return getBoundingBoxForString("Mg").getHeight();
     }

--- a/src/main/java/com/ait/lienzo/client/core/shape/Text.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/Text.java
@@ -92,7 +92,7 @@ public class Text extends Shape<Text>
         {
             text = "";
         }
-        setText(text).setFontFamily(globals.getDefaultFontFamily()).setFontStyle(globals.getDefaultFontStyle()).setFontSize(globals.getDefaultFontSize());
+        setText(text).setFontFamily(globals.getDefaultFontFamily()).setFontStyle(globals.getDefaultFontStyle()).setFontSize(globals.getDefaultFontSize()).setWrapBoundaries(null);
     }
 
     /**
@@ -121,7 +121,7 @@ public class Text extends Shape<Text>
         {
             size = globals.getDefaultFontSize();
         }
-        setText(text).setFontFamily(family).setFontStyle(globals.getDefaultFontStyle()).setFontSize(size);
+        setText(text).setFontFamily(family).setFontStyle(globals.getDefaultFontStyle()).setFontSize(size).setWrapBoundaries(null);
     }
 
     /**
@@ -155,7 +155,7 @@ public class Text extends Shape<Text>
         {
             size = globals.getDefaultFontSize();
         }
-        setText(text).setFontFamily(family).setFontStyle(style).setFontSize(size);
+        setText(text).setFontFamily(family).setFontStyle(style).setFontSize(size).setWrapBoundaries(null);
     }
 
     protected Text(JSONObject node, ValidationContext ctx) throws ValidationException
@@ -841,7 +841,13 @@ public class Text extends Shape<Text>
     @Override
     public List<Attribute> getBoundingBoxAttributes()
     {
-        return asAttributes(Attribute.TEXT, Attribute.FONT_SIZE, Attribute.FONT_STYLE, Attribute.FONT_FAMILY, Attribute.TEXT_UNIT, Attribute.TEXT_ALIGN, Attribute.TEXT_BASELINE);
+        return asAttributes(Attribute.TEXT, Attribute.FONT_SIZE, Attribute.FONT_STYLE, Attribute.FONT_FAMILY, Attribute.TEXT_UNIT, Attribute.TEXT_ALIGN, Attribute.TEXT_BASELINE, Attribute.WIDTH);
+    }
+
+    @Override
+    public List<Attribute> getTransformingAttributes()
+    {
+        return asAttributes(Attribute.TEXT, Attribute.FONT_SIZE, Attribute.FONT_STYLE, Attribute.FONT_FAMILY, Attribute.TEXT_UNIT, Attribute.TEXT_ALIGN, Attribute.TEXT_BASELINE, Attribute.WIDTH);
     }
 
     public BoundingBox getWrapBoundaries() {
@@ -850,6 +856,7 @@ public class Text extends Shape<Text>
 
     public Text setWrapBoundaries(BoundingBox boundaries) {
         wrapBoundaries = boundaries;
+        getAttributes().setWidth((null != boundaries)? boundaries.getWidth() : 0);
         return this;
     }
 
@@ -872,6 +879,8 @@ public class Text extends Shape<Text>
             addAttribute(Attribute.TEXT_ALIGN);
 
             addAttribute(Attribute.TEXT_BASELINE);
+
+            addAttribute(Attribute.WIDTH);
         }
 
         @Override
@@ -883,12 +892,5 @@ public class Text extends Shape<Text>
 
     private interface DrawString {
         void draw(Context2D c, String s, double xOffset, double lineNum);
-    }
-
-    private enum LinePlacement
-    {
-        TOP,
-        CENTER,
-        BOTTOM
     }
 }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresLayoutContainer.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresLayoutContainer.java
@@ -16,12 +16,19 @@
 
 package com.ait.lienzo.client.core.shape.wires;
 
+import java.util.HashMap;
+
+import com.ait.lienzo.client.core.Attribute;
+import com.ait.lienzo.client.core.event.AttributesChangedEvent;
+import com.ait.lienzo.client.core.event.AttributesChangedHandler;
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.IPrimitive;
 import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.tooling.common.api.java.util.UUID;
 import com.ait.tooling.nativetools.client.collection.NFastArrayList;
+import com.ait.tooling.nativetools.client.event.HandlerRegistrationManager;
+import com.google.gwt.event.shared.HandlerRegistration;
 
 /**
  * Basic layout container implementation.
@@ -49,6 +56,19 @@ public class WiresLayoutContainer implements LayoutContainer
     private double                           height;
 
     private final NFastArrayList<ChildEntry> children;
+
+    protected HandlerRegistrationManager attrHandlerRegs = new HandlerRegistrationManager();
+
+    protected HashMap<ObjectAttribute, HandlerRegistration> registrations = new HashMap<ObjectAttribute,HandlerRegistration>();
+
+    private final AttributesChangedHandler ShapeAttributesChangedHandler = new AttributesChangedHandler()
+    {
+        @Override
+        public void onAttributesChanged(AttributesChangedEvent event)
+        {
+            refresh();
+        }
+    };
 
     public WiresLayoutContainer()
     {
@@ -109,6 +129,11 @@ public class WiresLayoutContainer implements LayoutContainer
 
             final ChildEntry entry = new ChildEntry(child.getID(), layout);
             children.add(entry);
+            for (Attribute attribute : child.getTransformingAttributes()) {
+                HandlerRegistration reg = child.addAttributesChangedHandler(attribute,ShapeAttributesChangedHandler);
+                registrations.put(new ObjectAttribute(child,attribute), reg);
+                attrHandlerRegs.register(reg);
+            }
 
             doPositionChild(child, true);
 
@@ -123,9 +148,12 @@ public class WiresLayoutContainer implements LayoutContainer
 
         if (null != entry)
         {
-
             children.remove(entry);
 
+            for (Attribute attribute : child.getTransformingAttributes()) {
+                ObjectAttribute key = new ObjectAttribute(child,attribute);
+                attrHandlerRegs.deregister(registrations.remove(key));
+            }
         }
 
         group.remove(child);
@@ -163,6 +191,8 @@ public class WiresLayoutContainer implements LayoutContainer
     {
         children.clear();
         group.removeAll();
+        registrations.clear();
+        attrHandlerRegs.clear();
         return this;
     }
 
@@ -170,6 +200,7 @@ public class WiresLayoutContainer implements LayoutContainer
     public void destroy()
     {
         clear();
+        attrHandlerRegs.destroy();
         group.removeFromParent();
     }
 
@@ -401,4 +432,32 @@ public class WiresLayoutContainer implements LayoutContainer
         }
     }
 
+    private static class ObjectAttribute
+    {
+        public Object obj;
+        public Attribute attr;
+
+        public ObjectAttribute(Object obj, Attribute attr)
+        {
+            this.obj = obj;
+            this.attr = attr;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return obj.hashCode() ^ attr.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (o instanceof ObjectAttribute)
+            {
+                ObjectAttribute other = (ObjectAttribute) o;
+                return obj.equals(other.obj) && attr.equals(other.attr);
+            }
+            return false;
+        }
+    }
 }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresLayoutContainer.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresLayoutContainer.java
@@ -432,25 +432,25 @@ public class WiresLayoutContainer implements LayoutContainer
         }
     }
 
-    private static class ObjectAttribute
+    private final static class ObjectAttribute
     {
-        public Object obj;
-        public Attribute attr;
+        private final Object obj;
+        private final Attribute attr;
 
-        public ObjectAttribute(Object obj, Attribute attr)
+        private ObjectAttribute(Object obj, Attribute attr)
         {
             this.obj = obj;
             this.attr = attr;
         }
 
         @Override
-        public int hashCode()
+        public final int hashCode()
         {
             return obj.hashCode() ^ attr.hashCode();
         }
 
         @Override
-        public boolean equals(Object o)
+        public final boolean equals(Object o)
         {
             if (o instanceof ObjectAttribute)
             {

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresShape.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresShape.java
@@ -218,7 +218,15 @@ public class WiresShape extends WiresContainer
     {
         Objects.requireNonNull(handler);
 
-        return getHandlerManager().addHandler(WiresResizeEndEvent.TYPE, handler);
+        return getHandlerManager().addHandler(WiresResizeEndEvent.TYPE,
+                                              new WiresResizeEndHandler() {
+                                                  @Override
+                                                  public void onShapeResizeEnd(WiresResizeEndEvent event) {
+                                                      handler.onShapeResizeEnd(event);
+                                                      innerLayoutContainer.refresh();
+                                                      refresh();
+                                                  }
+                                              });
     }
 
     public String uuid()


### PR DESCRIPTION
Added basic text wrapping support for Text objects. By default, text will not wrap, and will behave as before. To enable text wrapping, call `setWrapBoundaries(BoundingBox box,Layout layout)`, where `box` is the bounding box for the object where the text resides, and `layout` is the the text layout within the BoundingBox. This patch was made for the 2.0.287-RELEASE (since that the one KIE Workbench (https://github.com/kiegroup/kie-wb-common) uses). Feedback appreciated.