### PR TITLE
[JBPM-5546] Allow setting what clicks count as a drag for a panel

### DIFF
--- a/src/main/java/com/ait/lienzo/client/widget/DragMouseControl.java
+++ b/src/main/java/com/ait/lienzo/client/widget/DragMouseControl.java
@@ -1,0 +1,25 @@
+package com.ait.lienzo.client.widget;
+
+public enum DragMouseControl {
+    LEFT_MOUSE_ONLY (true,false,false),
+    MIDDLE_MOUSE_ONLY (false,true,false),
+    RIGHT_MOUSE_ONLY (false,false,true),
+    LEFT_AND_RIGHT_MOUSE (true,false,true),
+    LEFT_AND_MIDDLE_MOUSE (true,true,false),
+    RIGHT_AND_MIDDLE_MOUSE (false,true,true),
+    ANY_MOUSE_BUTTON (true,true,true);
+
+    public final boolean allowLeft;
+    public final boolean allowMiddle;
+    public final boolean allowRight;
+
+    DragMouseControl(boolean left, boolean middle, boolean right){
+        allowLeft = left;
+        allowMiddle = middle;
+        allowRight = right;
+    }
+
+    public boolean allowDrag(boolean isLeft, boolean isMiddle, boolean isRight) {
+        return !((isLeft && !allowLeft) || (isMiddle && !allowMiddle) || (isRight && !allowRight));
+    }
+}

--- a/src/main/java/com/ait/lienzo/client/widget/LienzoHandlerManager.java
+++ b/src/main/java/com/ait/lienzo/client/widget/LienzoHandlerManager.java
@@ -55,6 +55,7 @@ import com.ait.tooling.common.api.java.util.function.Predicate;
 import com.ait.tooling.nativetools.client.collection.NFastArrayList;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.Style.Cursor;
 import com.google.gwt.dom.client.Touch;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -115,6 +116,12 @@ final class LienzoHandlerManager
 
     private boolean           m_dragging_mouse_pressed = false;
 
+    private boolean           m_mouse_button_left      = false;
+
+    private boolean           m_mouse_button_middle      = false;
+
+    private boolean           m_mouse_button_right      = false;
+
     private DragMode          m_drag_mode              = null;
 
     private IPrimitive<?>     m_drag_node              = null;
@@ -174,6 +181,9 @@ final class LienzoHandlerManager
             public void onClick(final ClickEvent event)
             {
                 onNodeMouseClick(new NodeMouseClickEvent(event));
+                m_mouse_button_left = (event.getNativeButton() == NativeEvent.BUTTON_LEFT);
+                m_mouse_button_middle = (event.getNativeButton() == NativeEvent.BUTTON_MIDDLE);
+                m_mouse_button_right = (event.getNativeButton() == NativeEvent.BUTTON_RIGHT);
 
                 event.preventDefault();
             }
@@ -184,6 +194,9 @@ final class LienzoHandlerManager
             public void onDoubleClick(final DoubleClickEvent event)
             {
                 onNodeMouseDoubleClick(new NodeMouseDoubleClickEvent(event));
+                m_mouse_button_left = (event.getNativeButton() == NativeEvent.BUTTON_LEFT);
+                m_mouse_button_middle = (event.getNativeButton() == NativeEvent.BUTTON_MIDDLE);
+                m_mouse_button_right = (event.getNativeButton() == NativeEvent.BUTTON_RIGHT);
 
                 event.preventDefault();
             }
@@ -207,6 +220,10 @@ final class LienzoHandlerManager
 
                     return;
                 }
+                m_mouse_button_left = (event.getNativeButton() == NativeEvent.BUTTON_LEFT);
+                m_mouse_button_middle = (event.getNativeButton() == NativeEvent.BUTTON_MIDDLE);
+                m_mouse_button_right = (event.getNativeButton() == NativeEvent.BUTTON_RIGHT);
+
                 onNodeMouseMove(nevent);
 
                 event.preventDefault();
@@ -223,6 +240,11 @@ final class LienzoHandlerManager
                 {
                     return;
                 }
+
+                m_mouse_button_left = (event.getNativeButton() == NativeEvent.BUTTON_LEFT);
+                m_mouse_button_middle = (event.getNativeButton() == NativeEvent.BUTTON_MIDDLE);
+                m_mouse_button_right = (event.getNativeButton() == NativeEvent.BUTTON_RIGHT);
+
                 onNodeMouseUp(nevent);
             }
         });
@@ -239,6 +261,11 @@ final class LienzoHandlerManager
 
                     return;
                 }
+
+                m_mouse_button_left = (event.getNativeButton() == NativeEvent.BUTTON_LEFT);
+                m_mouse_button_middle = (event.getNativeButton() == NativeEvent.BUTTON_MIDDLE);
+                m_mouse_button_right = (event.getNativeButton() == NativeEvent.BUTTON_RIGHT);
+
                 onNodeMouseDown(nevent);
 
                 event.preventDefault();
@@ -658,7 +685,10 @@ final class LienzoHandlerManager
         {
             doDragCancel(event);
         }
-        m_dragging_mouse_pressed = true;
+        if (m_lienzo.getDragMouseButtons().allowDrag(m_mouse_button_left,m_mouse_button_middle,m_mouse_button_right))
+        {
+            m_dragging_mouse_pressed = true;
+        }
 
         fireEventForPrimitive(findPrimitiveForEventType(event, event.getNodeEvent().getAssociatedType()), event);
     }

--- a/src/main/java/com/ait/lienzo/client/widget/LienzoPanel.java
+++ b/src/main/java/com/ait/lienzo/client/widget/LienzoPanel.java
@@ -71,6 +71,8 @@ public class LienzoPanel extends FocusPanel implements RequiresResize, ProvidesR
 
     private Cursor               m_select_cursor;
 
+    private DragMouseControl     m_drag_mouse_control;
+
     public LienzoPanel()
     {
         this(new Viewport());
@@ -119,6 +121,8 @@ public class LienzoPanel extends FocusPanel implements RequiresResize, ProvidesR
         m_high = high;
 
         m_flex = flex;
+
+        m_drag_mouse_control = DragMouseControl.LEFT_MOUSE_ONLY;
 
         if (LienzoCore.IS_CANVAS_SUPPORTED)
         {
@@ -176,6 +180,18 @@ public class LienzoPanel extends FocusPanel implements RequiresResize, ProvidesR
             return AutoScaleType.NONE;
         }
         return m_auto;
+    }
+
+    public LienzoPanel setDragMouseButtons(DragMouseControl controls)
+    {
+        m_drag_mouse_control = controls;
+
+        return this;
+    }
+
+    public DragMouseControl getDragMouseButtons()
+    {
+        return m_drag_mouse_control;
     }
 
     public LienzoPanel setTransform(final Transform transform)


### PR DESCRIPTION
Modified LienzoHandlerManager to only start the drag action when it is allowed. Created enum DragMouseControl which allow user to specify what mouse buttons cause a drag action for a LienzoPanel. Default currently is left mouse only, but could be changed to all mouse buttons to preserve previous behaviour. Based on the 2.0.287-RELEASE.