### PR TITLE
SelectionManager now correctly handles externally connected connectors

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/DefaultSelectionListener.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/DefaultSelectionListener.java
@@ -2,6 +2,7 @@ package com.ait.lienzo.client.core.shape.wires;
 
 import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresConnectorControlImpl;
+import com.ait.tooling.nativetools.client.util.Console;
 
 public class DefaultSelectionListener implements SelectionListener
 {
@@ -20,20 +21,21 @@ public class DefaultSelectionListener implements SelectionListener
     {
         SelectionManager.ChangedItems changed = selectedItems.getChanged();
 
-//
+
+// leaving in comments for now, as I re-enable those during debug, if there are problems.
 //            for (WiresShape shape : selectedItems.getShapes())
 //            {
-//                Console.get().info(shape.getContainer().getUserData().toString());
+//                Console.get().info(shape.getContainer().getUserData().toString() + " : " + shape.getGroup().getLocation());
 //            }
 //
 //            for (WiresConnector connector : selectedItems.getConnectors())
 //            {
-//                Console.get().info("connector + "  + connector.getGroup().uuid() );
+//                Console.get().info("connector + " + connector.getGroup().uuid());
 //            }
 //
 //            for (WiresShape shape : changed.getRemovedShapes())
 //            {
-//                Console.get().info("removed" + shape.getContainer().getUserData().toString());
+//                Console.get().info("removed" + shape.getContainer().getUserData().toString() + " : " + shape.getGroup().getLocation());
 //            }
 //
 //            for (WiresConnector connector : changed.getRemovedConnectors())
@@ -43,16 +45,17 @@ public class DefaultSelectionListener implements SelectionListener
 //
 //            for (WiresShape shape : changed.getAddedShapes())
 //            {
-//                Console.get().info("added" + shape.getContainer().getUserData().toString());
+//                Console.get().info("added" + shape.getContainer().getUserData().toString() + " : " + shape.getGroup().getLocation());
 //            }
 //
 //            for (WiresConnector connector : changed.getAddedConnectors())
 //            {
 //                Console.get().info("added connector + "  + connector.getGroup().uuid() );
 //            }
-
+//
         for (WiresShape shape : changed.getRemovedShapes())
         {
+            //Console.get().info("unselected" + shape.getContainer().getUserData().toString() + " : " + shape.getGroup().getLocation());
             unselect(shape);
         }
 
@@ -63,10 +66,12 @@ public class DefaultSelectionListener implements SelectionListener
 
         if (!selectedItems.isSelectionGroup() && selectedItems.size() == 1)
         {
+            // it's one or the other, so attempt both, it'll short circuit if the first selects.
             if (selectedItems.getShapes().size() == 1)
             {
                 for (WiresShape shape : selectedItems.getShapes())
                 {
+//                    Console.get().info("select" + shape.getContainer().getUserData().toString() + " : " + shape.getGroup().getLocation());
                     select(shape);
                     break;
                 }
@@ -78,6 +83,22 @@ public class DefaultSelectionListener implements SelectionListener
                     select(connector);
                     break;
                 }
+            }
+        }
+        else if (selectedItems.isSelectionGroup())
+        {
+            // we don't which have selectors shown, if any. Just iterate and unselect all
+            // null check will do nothing, if it's already unselected.
+            for (WiresShape shape : selectedItems.getShapes())
+            {
+//                Console.get().info("unselected" + shape.getContainer().getUserData().toString() + " : " + shape.getGroup().getLocation());
+                unselect(shape);
+            }
+
+
+            for (WiresConnector connector : selectedItems.getConnectors())
+            {
+                unselect(connector);
             }
         }
     }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/MagnetManager.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/MagnetManager.java
@@ -43,7 +43,6 @@ import com.ait.lienzo.shared.core.types.Direction;
 import com.ait.lienzo.shared.core.types.DragMode;
 import com.ait.tooling.nativetools.client.collection.NFastStringMap;
 import com.ait.tooling.nativetools.client.event.HandlerRegistrationManager;
-import com.ait.tooling.nativetools.client.util.Console;
 
 public class MagnetManager
 {

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/SelectionManager.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/SelectionManager.java
@@ -481,7 +481,7 @@ public class SelectionManager implements NodeMouseDoubleClickHandler, NodeMouseC
                 {
                     remove(shape);
                 }
-                else  if (hasSameParentsAsSelection(shape))
+                else  if (hasSameParentsAsSelection(shape) && shape.getDockedTo() == null) // cannot docked shapes
                 {
                     removeChildShape(shape.getChildShapes());
                     add(shape);
@@ -823,6 +823,11 @@ public class SelectionManager implements NodeMouseDoubleClickHandler, NodeMouseC
         // first build a map of all shapes that intersect with teh selection rectangle. Nested shapes will be used later.
         for (WiresShape shape : m_wiresManager.getShapesMap().values())
         {
+            if ( shape.getDockedTo() != null)
+            {
+                // docked items cannot be added to a selection, only their parent they are docked to
+                continue;
+            }
             nodeBox = shape.getContainer().getComputedBoundingPoints().getBoundingBox();
             if (selectionBox.intersects(nodeBox))
             {

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/SelectionManager.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/SelectionManager.java
@@ -481,13 +481,25 @@ public class SelectionManager implements NodeMouseDoubleClickHandler, NodeMouseC
                 {
                     remove(shape);
                 }
-                else  if (findParentIfInSelection(shape)==null)
+                else  if (hasSameParentsAsSelection(shape))
                 {
                     removeChildShape(shape.getChildShapes());
                     add(shape);
                 }
             }
             notifyListener(event);
+        }
+
+        private boolean hasSameParentsAsSelection(WiresShape subjectShape)
+        {
+            for (WiresShape existingShape : m_shapes)
+            {
+                if (existingShape.getParent() != subjectShape.getParent())
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         private WiresShape findParentIfInSelection(WiresShape subjectShape)

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresConnection.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresConnection.java
@@ -23,6 +23,7 @@ import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.shared.core.types.ArrowEnd;
 import com.ait.lienzo.shared.core.types.Direction;
+import com.ait.tooling.nativetools.client.util.Console;
 
 public class WiresConnection extends AbstractControlHandle
 {
@@ -207,6 +208,11 @@ public class WiresConnection extends AbstractControlHandle
     public WiresMagnet getMagnet()
     {
         return m_magnet;
+    }
+
+    public WiresConnection getOppositeConnection()
+    {
+        return this == m_connector.getHeadConnection() ? m_connector.getTailConnection() : m_connector.getHeadConnection();
     }
 
     public boolean isSpecialConnection()

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresConnector.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresConnector.java
@@ -36,6 +36,7 @@ import com.ait.lienzo.client.core.shape.OrthogonalPolyLine;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresConnectorControl;
 import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.client.core.types.Point2DArray;
 import com.ait.lienzo.client.core.util.Geometry;
 import com.ait.lienzo.shared.core.types.ArrowEnd;
 import com.ait.lienzo.shared.core.types.Direction;
@@ -46,6 +47,41 @@ import static com.ait.lienzo.client.core.shape.wires.IControlHandle.ControlHandl
 
 public class WiresConnector
 {
+    public static boolean updateHeadTailForRefreshedConnector(WiresConnector c)
+    {
+        // Iterate each refreshed line and get the new points for the decorators
+        if (c.getLine().getPathPartList().size() < 1)
+        {
+            // only do this for lines that have had refresh called
+            AbstractDirectionalMultiPointShape<?> line = c.getLine();
+
+            if ( c.isSpecialConnection() && line.getPathPartList().size() == 0)
+            {
+                // if getPathPartList is empty, it was refreshed due to a point change
+                c.updateForSpecialConnections(false);
+            }
+
+            final boolean prepared = line.isPathPartListPrepared(c.getLine().getAttributes());
+
+            if (!prepared)
+            {
+                return true;
+            }
+
+            Point2DArray points     = line.getPoint2DArray();
+            Point2D      p0         = points.get(0);
+            Point2D      p1         = line.getHeadOffsetPoint();
+            Point2DArray headPoints = new Point2DArray(p1, p0);
+            c.getHeadDecorator().draw(headPoints);
+
+            p0 = points.get(points.size() - 1);
+            p1 = line.getTailOffsetPoint();
+            Point2DArray tailPoints = new Point2DArray(p1, p0);
+            c.getTailDecorator().draw(tailPoints);
+        }
+        return false;
+    }
+
     public interface WiresConnectorHandler extends NodeDragStartHandler, NodeDragMoveHandler, NodeDragEndHandler, NodeMouseClickHandler, NodeMouseDoubleClickHandler
     {
 

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresManager.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresManager.java
@@ -17,7 +17,6 @@
 
 package com.ait.lienzo.client.core.shape.wires;
 
-import com.ait.lienzo.client.core.shape.AbstractDirectionalMultiPointShape;
 import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.lienzo.client.core.shape.wires.event.WiresResizeEndEvent;
 import com.ait.lienzo.client.core.shape.wires.event.WiresResizeEndHandler;
@@ -28,8 +27,6 @@ import com.ait.lienzo.client.core.shape.wires.handlers.WiresDockingAndContainmen
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresShapeControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresControlFactoryImpl;
 import com.ait.lienzo.client.core.types.OnLayerBeforeDraw;
-import com.ait.lienzo.client.core.types.Point2D;
-import com.ait.lienzo.client.core.types.Point2DArray;
 import com.ait.tooling.nativetools.client.collection.NFastArrayList;
 import com.ait.tooling.nativetools.client.collection.NFastStringMap;
 import com.ait.tooling.nativetools.client.event.HandlerRegistrationManager;
@@ -124,42 +121,14 @@ public final class WiresManager
             // changed and thus will be reparsed.
             for (WiresConnector c : m_wiresManager.getConnectorList())
             {
-                // Iterate each refreshed line and get the new points for the decorators
-                if (c.getLine().getPathPartList().size() < 1)
+                if (WiresConnector.updateHeadTailForRefreshedConnector(c))
                 {
-                    // only do this for lines that have had refresh called
-                    AbstractDirectionalMultiPointShape<?> line = c.getLine();
-
-                    if ( c.isSpecialConnection() && line.getPathPartList().size() == 0)
-                    {
-                        // if getPathPartList is empty, it was refreshed due to a point change
-                        c.updateForSpecialConnections(false);
-                    }
-
-                    final boolean prepared = line.isPathPartListPrepared(c.getLine().getAttributes());
-
-                    if (!prepared)
-                    {
-                        return false;
-                    }
-
-                    Point2DArray points = line.getPoint2DArray();
-                    Point2D p0 = points.get(0);
-                    Point2D p1 = line.getHeadOffsetPoint();
-                    Point2DArray headPoints = new Point2DArray(p1, p0);
-                    c.getHeadDecorator().draw(headPoints);
-
-                    p0 = points.get(points.size() - 1);
-                    p1 = line.getTailOffsetPoint();
-                    Point2DArray tailPoints = new Point2DArray(p1, p0);
-                    c.getTailDecorator().draw(tailPoints);
-
+                    return false;
                 }
             }
 
             return true;
         }
-
     }
 
     public MagnetManager getMagnetManager()

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectionControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectionControlImpl.java
@@ -234,6 +234,9 @@ public class WiresConnectionControlImpl implements WiresConnectionControl
     @Override
     public boolean dragAdjust(final Point2D dxy)
     {
+        // this is redetermined on each drag adjust
+        m_current_magnet = null;
+
         int x = (int) (m_startX + dxy.getX());
         int y = (int) (m_startY + dxy.getY());
 
@@ -273,7 +276,6 @@ public class WiresConnectionControlImpl implements WiresConnectionControl
                     }
                     m_magnets = null;
                     m_colorKey = null;
-                    m_current_magnet = null;
                 }
                 else
                 {

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
@@ -163,8 +163,8 @@ public class WiresShapeControlImpl implements WiresShapeControl
         }
         else
         {
-            updateSpecialConnections(m_connectorsWithSpecialConnections,
-                                     false);
+            updateSpecialConnections(m_connectorsWithSpecialConnections, true);
+            updateNestedShapes(m_shape);
         }
 
         if (m_alignAndDistributeControl != null)
@@ -429,22 +429,27 @@ public class WiresShapeControlImpl implements WiresShapeControl
             }
         }
 
-        updateSpecialConnections(m_connectorsWithSpecialConnections,
-                                 false);
+        updateSpecialConnections(m_connectorsWithSpecialConnections, false);
+        updateNestedShapes(m_shape);
 
-        if (m_shape.getChildShapes() != null && !m_shape.getChildShapes().isEmpty())
+        return adjusted1 && adjusted2;
+
+    }
+
+    public static void updateNestedShapes(WiresShape shape)
+    {
+        // While the nested shapes don't have attribute changes, when the parent moves, the connectors are on the root layer and thus must still be updated
+        if (shape.getChildShapes() != null && !shape.getChildShapes().isEmpty())
         {
-            for (WiresShape child : m_shape.getChildShapes())
+            for (WiresShape child : shape.getChildShapes())
             {
+                updateNestedShapes(child); // recurse to leafs
                 if (child.getMagnets() != null)
                 {
                     child.getMagnets().shapeMoved();
                 }
             }
         }
-
-        return adjusted1 && adjusted2;
-
     }
 
     public static void updateSpecialConnections(WiresConnector[] connectors,

--- a/src/main/java/com/ait/lienzo/client/core/types/BoundingBox.java
+++ b/src/main/java/com/ait/lienzo/client/core/types/BoundingBox.java
@@ -307,6 +307,11 @@ public final class BoundingBox
         return toJSONString().hashCode();
     }
 
+    public void offset(int dx, int dy)
+    {
+        m_jso.offset(dx, dy);
+    }
+
     public final static class BoundingBoxJSO extends JavaScriptObject
     {
         protected BoundingBoxJSO()
@@ -361,6 +366,13 @@ public final class BoundingBox
 			if (y > this.maxy) {
 				this.maxy = y;
 			}
+        }-*/;
+        final native void offset(double dx, double dy)
+        /*-{
+            this.minx = this.minx + dx;
+            this.maxx = this.maxx + dx;
+            this.miny = this.miny + dy;
+            this.maxy = this.maxy + dy;
         }-*/;
     }
 }


### PR DESCRIPTION
-Shift operations now correctly add and remove shapes
-Lots of bug fixes so it’s now more robust
-Fixed bug when dragging a connection from a nested shape over a parent that has no magnets, which would make it appear “stuck” on the inner magnet. This bug was not related to the SelectionManager work.