### PR TITLE
JBPM-6340: Wires connectors do not cause exception when shape is resized

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresConnector.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresConnector.java
@@ -342,6 +342,10 @@ public class WiresConnector
             BoundingBox box               = path.getBoundingBox();
             Point2D c = Geometry.findCenter(box);
             Point2D     intersectPoint    = Geometry.getPathIntersect(connection, path, c, pointIndex);
+            if (null == intersectPoint) {
+                intersectPoint = new Point2D();
+            }
+
             Direction   d                 = MagnetManager.getDirection(intersectPoint, box);
 
             Point2D loc = path.getComputedLocation().copy();

--- a/src/main/java/com/ait/lienzo/client/core/util/Geometry.java
+++ b/src/main/java/com/ait/lienzo/client/core/util/Geometry.java
@@ -1122,12 +1122,21 @@ public final class Geometry
             // without this the project throw an error as you cannot unit() something of length 0,0
             p.offset(offsetP.getX(), offsetP.getY());
         }
-        p = getProjection(c, p, width);
+        try {
+            p = getProjection(c,
+                              p,
+                              width);
 
-        Set<Point2D>[] set    =  Geometry.getCardinalIntersects(path, new Point2DArray(c, p));
-        Point2DArray   points = Geometry.removeInnerPoints(c, set);
+            Set<Point2D>[] set = Geometry.getCardinalIntersects(path,
+                                                                new Point2DArray(c,
+                                                                                 p));
+            Point2DArray points = Geometry.removeInnerPoints(c,
+                                                             set);
 
-        return points.get(1);
+            return (points.size() > 1) ? points.get(1) : null;
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     public static Point2DArray getIntersectPolyLinePath(Point2DArray points, PathPartList path, boolean closed)


### PR DESCRIPTION
This is a fix for this issue: https://issues.jboss.org/browse/JBPM-6340. The issue is caused by `Geometry.getPathIntersect()`, which sometimes incorrectly returns a Point2D without a corresponding JSO object due to accessing a non-existing array element. `Geometry.getPathIntersect()` will now return null if the array does not contain enough elements or an exception occurs.