### PR TITLE
JBPM-6045: Containment highlighting now works after panning/scaling

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresDockingAndContainmentControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresDockingAndContainmentControlImpl.java
@@ -419,7 +419,8 @@ public class WiresDockingAndContainmentControlImpl implements WiresDockingAndCon
                                         scratchPad,
                                         shape,
                                         isDockingAllowed,
-                                        hotSpotSize);
+                                        hotSpotSize,
+                                        m_layer);
     }
 
     protected ColorMapBackedPicker makeColorMapBackedPicker(final WiresLayer m_layer,


### PR DESCRIPTION
This fixes incorrect highlighting for containment caused by a pan or a zoom.