### PR TITLE
Wires bug fixing - re-enable docking once composite control operations are completed/reset

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresCompositeControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresCompositeControlImpl.java
@@ -147,8 +147,6 @@ public class WiresCompositeControlImpl
         Point2D candidate = null;
         if (shape.getControl().getContainmentControl().isAllow()) {
             candidate = shape.getControl().getContainmentControl().getCandidateLocation();
-        } else if (shape.getControl().getDockingControl().isAllow()) {
-            candidate = shape.getControl().getDockingControl().getCandidateLocation();
         }
         // Check if the candidate location is relative to the parent.
         if (null != candidate) {
@@ -276,8 +274,8 @@ public class WiresCompositeControlImpl
     @Override
     public void clear() {
         for (WiresShape shape : selectionContext.getShapes()) {
-            enableDocking(shape.getControl());
             shape.getControl().clear();
+            enableDocking(shape.getControl());
         }
         clearState();
     }
@@ -286,7 +284,7 @@ public class WiresCompositeControlImpl
     public void reset() {
         for (WiresShape shape : selectionContext.getShapes()) {
             shape.getControl().reset();
-            shape.shapeMoved();
+            enableDocking(shape.getControl());
         }
         for (WiresConnector connector : selectionContext.getConnectors()) {
             WiresConnector.WiresConnectorHandler handler = connector.getWiresConnectorHandler();
@@ -299,6 +297,10 @@ public class WiresCompositeControlImpl
     @Override
     public Point2D getAdjust() {
         return delta;
+    }
+
+    public Context getContext() {
+        return selectionContext;
     }
 
     @Override

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
@@ -200,6 +200,7 @@ public class WiresShapeControlImpl
         if (null != m_alignAndDistributeControl) {
             m_alignAndDistributeControl.dragEnd();
         }
+        getShape().shapeMoved();
         clearState();
     }
 


### PR DESCRIPTION
Hey @SprocketNYC 

If you did not built yet the `2.0.294-RELEASE`, please here is a fix for a minor issue that would be nice to include, if possible.

PS: Cannot ensure no more fixes will be required in the next few weeks, QE is starting to test the new released stuff, so will try to apply next fixes in our codebase (on top of lienzo) where possible, and wait for the new re-organization so for creating the PRs on the new place. But this also depends on you, I mean if you think you'll take long time to do this we probably will need to create PRs and releases in `ahome-it` yet... we are continuously adding features and bug fixings at this stage, we cannot stop.. :)

Thanks in advance!