### PR TITLE
Refactor to enable SVG export.  Cherry pick commit from kiegroup

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/Context2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/Context2D.java
@@ -42,28 +42,48 @@ import com.google.gwt.dom.client.Element;
  */
 public class Context2D
 {
-    private final NativeContext2D m_jso;
+    private final INativeContext2D m_jso;
 
     public Context2D(final CanvasElement element)
     {
         this(NativeContext2D.make(element));
     }
 
-    public Context2D(final NativeContext2D jso)
+    public Context2D(final INativeContext2D jso)
     {
         m_jso = jso;
     }
 
-    public NativeContext2D getNativeContext()
+    public INativeContext2D getNativeContext()
     {
         return m_jso;
     }
 
+    /**
+     * Save and push a new container context to the stack
+     */
+    public void saveContainer(){
+        m_jso.saveContainer();
+    }
+
+    /**
+     * Restore and pop the current container context from the stack returning to the previous context
+     */
+    public void restoreContainer(){
+        m_jso.restoreContainer();
+    }
+
+    /**
+     * Saves the current context state (i.e style, fill, stroke...) pushing to the stack
+     */
     public void save()
     {
         m_jso.save();
     }
 
+    /**
+     * Restore the saved context state (i.e style, fill, stroke...) by popping from the stack
+     */
     public void restore()
     {
         m_jso.restore();

--- a/src/main/java/com/ait/lienzo/client/core/INativeContext2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/INativeContext2D.java
@@ -1,0 +1,175 @@
+/*
+   Copyright (c) 2018 Ahome' Innovation Technologies. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package com.ait.lienzo.client.core;
+
+import com.ait.lienzo.client.core.types.ImageData;
+import com.ait.lienzo.client.core.types.LinearGradient;
+import com.ait.lienzo.client.core.types.PathPartList;
+import com.ait.lienzo.client.core.types.PatternGradient;
+import com.ait.lienzo.client.core.types.RadialGradient;
+import com.ait.lienzo.client.core.types.Shadow;
+import com.ait.lienzo.client.core.types.TextMetrics;
+import com.ait.lienzo.client.core.types.Transform;
+import com.ait.tooling.nativetools.client.collection.NFastDoubleArrayJSO;
+import com.google.gwt.dom.client.Element;
+
+public interface INativeContext2D {
+
+    void initDeviceRatio();
+
+    void saveContainer();
+
+    void restoreContainer();
+
+    void save();
+
+    void restore();
+
+    void beginPath();
+
+    void closePath();
+
+    void moveTo(double x, double y);
+
+    void lineTo(double x, double y);
+
+    void setGlobalCompositeOperation(String operation);
+
+    void setLineCap(String lineCap);
+
+    void setLineJoin(String lineJoin);
+
+    void quadraticCurveTo(double cpx, double cpy, double x, double y);
+
+    void arc(double x, double y, double radius, double startAngle, double endAngle);
+
+    void arc(double x, double y, double radius, double startAngle, double endAngle, boolean antiClockwise);
+
+    void ellipse(double x, double y, double rx, double ry, double ro, double sa, double ea, boolean ac);
+
+    void ellipse(double x, double y, double rx, double ry, double ro, double sa, double ea);
+
+    void arcTo(double x1, double y1, double x2, double y2, double radius);
+
+    void bezierCurveTo(double cp1x, double cp1y, double cp2x, double cp2y, double x, double y);
+
+    void clearRect(double x, double y, double w, double h);
+
+    void clip();
+
+    void fill();
+
+    void stroke();
+
+    void fillRect(double x, double y, double w, double h);
+
+    void fillText(String text, double x, double y);
+
+    void fillTextWithGradient(String text, double x, double y, double sx, double sy, double ex, double ey, String color);
+
+    void fillText(String text, double x, double y, double maxWidth);
+
+    void setFillColor(String fill);
+
+    void rect(double x, double y, double w, double h);
+
+    void rotate(double angle);
+
+    void scale(double sx, double sy);
+
+    void setStrokeColor(String color);
+
+    void setStrokeWidth(double width);
+
+    void setImageSmoothingEnabled(boolean enabled);
+
+    void setFillGradient(LinearGradient.LinearGradientJSO grad);
+
+    void setFillGradient(PatternGradient.PatternGradientJSO grad);
+
+    void setFillGradient(RadialGradient.RadialGradientJSO grad);
+
+    void transform(Transform.TransformJSO jso);
+
+    void transform(double d0, double d1, double d2, double d3, double d4, double d5);
+
+    void setTransform(Transform.TransformJSO jso);
+
+    void setTransform(double d0, double d1, double d2, double d3, double d4, double d5);
+
+    void setToIdentityTransform();
+
+    void setTextFont(String font);
+
+    void setTextBaseline(String baseline);
+
+    void setTextAlign(String align);
+
+    void strokeText(String text, double x, double y);
+
+    void setGlobalAlpha(double alpha);
+
+    void translate(double x, double y);
+
+    void setShadow(Shadow.ShadowJSO shadow);
+
+    boolean isSupported(String feature);
+
+    boolean isPointInPath(double x, double y);
+
+    ImageData getImageData(double x, double y, double width, double height);
+
+    ImageData createImageData(double width, double height);
+
+    ImageData createImageData(ImageData data);
+
+    void putImageData(ImageData imageData, double x, double y);
+
+    void putImageData(ImageData imageData, double x, double y, double dx, double dy, double dw, double dh);
+
+    TextMetrics measureText(String text);
+
+    void drawImage(Element image, double x, double y);
+
+    void drawImage(Element image, double x, double y, double w, double h);
+
+    void drawImage(Element image, double sx, double sy, double sw, double sh, double x, double y, double w, double h);
+
+    void resetClip();
+
+    void setMiterLimit(double limit);
+
+    void setLineDash(NFastDoubleArrayJSO dashes);
+
+    void setLineDashOffset(double offset);
+
+    double getBackingStorePixelRatio();
+
+    boolean path(PathPartList.PathPartListJSO list);
+
+    boolean clip(PathPartList.PathPartListJSO list);
+
+    void fill(Path2D.NativePath2D path);
+
+    void stroke(Path2D.NativePath2D path);
+
+    void clip(Path2D.NativePath2D path);
+
+    Path2D.NativePath2D getCurrentPath();
+
+    void setCurrentPath(Path2D.NativePath2D path);
+}

--- a/src/main/java/com/ait/lienzo/client/core/NativeContext2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/NativeContext2D.java
@@ -36,8 +36,7 @@ import com.google.gwt.dom.client.Element;
  * @see <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#2dcontext">Canvas 2d Context</a> 
  */
 
-public final class NativeContext2D extends JavaScriptObject
-{
+public class NativeContext2D extends JavaScriptObject implements INativeContext2D {
     private static final native NativeContext2D make_0(CanvasElement element)
     /*-{
 		return element.getContext("2d");
@@ -124,6 +123,14 @@ public final class NativeContext2D extends JavaScriptObject
 		}
 		return this;
     }-*/;
+
+    public final void saveContainer() {
+        this.save();
+    }
+
+    public final void restoreContainer() {
+        this.restore();
+    }
 
     public final native void save()
     /*-{

--- a/src/main/java/com/ait/lienzo/client/core/Path2D.java
+++ b/src/main/java/com/ait/lienzo/client/core/Path2D.java
@@ -189,7 +189,7 @@ public class Path2D
         return this;
     }
 
-    static final class NativePath2D extends JavaScriptObject
+    public static final class NativePath2D extends JavaScriptObject
     {
         protected NativePath2D()
         {

--- a/src/main/java/com/ait/lienzo/client/core/shape/Layer.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/Layer.java
@@ -690,7 +690,7 @@ public class Layer extends ContainerNode<IPrimitive<?>, Layer>
         return draw(getContext());
     }
 
-    protected Layer draw(Context2D context)
+    public Layer draw(Context2D context)
     {
         if (LienzoCore.IS_CANVAS_SUPPORTED)
         {

--- a/src/main/java/com/ait/lienzo/client/core/shape/Node.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/Node.java
@@ -100,7 +100,6 @@ import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONValue;
-import com.google.gwt.touch.client.Point;
 
 /**
  * Node is the base class for {@link ContainerNode} and {@link Shape}.
@@ -487,7 +486,7 @@ public abstract class Node<T extends Node<T>> implements IDrawable<T>
         }
         if (context.isDrag() || isVisible())
         {
-            context.save();
+            context.saveContainer();
 
             final Transform xfrm = getPossibleNodeTransform();
 
@@ -497,7 +496,7 @@ public abstract class Node<T extends Node<T>> implements IDrawable<T>
             }
             drawWithoutTransforms(context, alpha, bounds);
 
-            context.restore();
+            context.restoreContainer();
         }
     }
 


### PR DESCRIPTION
This is a refactor necessary to use [canvas2svg](https://github.com/gliffy/canvas2svg) library, where basically we extracted the `NativeContex2d` that allow us to inject a custom context to build the SVG, based on the same calls as for the native canvas context.
There was need to split the `context.save/restore` to `saveContainer/restoreContainer` because there was needed to distinct the calld when using the SVG library to create the SVG groups. The original behavior is the same because the saveContainer/restoreContainer is simply calling the save and restore methods.
@romartin 
@mdproctor 