### PR TITLE
Dock fix, polyline fix

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresControlPointHandlerImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresControlPointHandlerImpl.java
@@ -48,7 +48,10 @@ public class WiresControlPointHandlerImpl implements WiresControlPointHandler {
     {
         IPrimitive<?> primitive = (IPrimitive<?>) event.getSource();
         Point2D adjust = m_connectorControl.adjustControlPointAt(primitive.getX(), primitive.getY(), event.getX(), event.getY());
-        primitive.setX(adjust.getX());
-        primitive.setY(adjust.getY());
+        if (adjust != null)
+        {
+            primitive.setX(adjust.getX());
+            primitive.setY(adjust.getY());
+        }
     }
 }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeControlImpl.java
@@ -96,7 +96,6 @@ public class WiresShapeControlImpl extends AbstractWiresBoundsConstraintControl 
         // Important - skip the shape and its children, if any, from the picker.
         // Otherwise children or the shape itself are being processed by the parent picker
         // and it ends up with wrong parent-child nested issues.
-
         final NFastArrayList<WiresShape> shapesToSkip = parentPickerControl.getPickerOptions().getShapesToSkip();
 
         shapesToSkip.clear();
@@ -109,26 +108,26 @@ public class WiresShapeControlImpl extends AbstractWiresBoundsConstraintControl 
         {
             shapesToSkip.add(children.get(i));
         }
-        // Delegate mvoe start to the shape's docking control
 
+        // Delegate move start to the shape's docking control
         if (m_dockingAndControl != null)
         {
             m_dockingAndControl.onMoveStart(x, y);
         }
-        // Delegate mvoe start to the shape's containment control
 
+        // Delegate move start to the shape's containment control
         if (m_containmentControl != null)
         {
             m_containmentControl.onMoveStart(x, y);
         }
-        // Delegate mvoe start to the align and distribute control.
 
+        // Delegate move start to the align and distribute control.
         if (m_alignAndDistributeControl != null)
         {
             m_alignAndDistributeControl.dragStart();
         }
-        // index nested shapes that have special connectors, to avoid searching during drag.
 
+        // index nested shapes that have special connectors, to avoid searching during drag.
         m_connectorsWithSpecialConnections = ShapeControlUtils.collectionSpecialConnectors(getShape());
     }
 
@@ -180,7 +179,8 @@ public class WiresShapeControlImpl extends AbstractWiresBoundsConstraintControl 
         {
             final Point2D dadjust = m_dockingAndControl.getAdjust();
             double adjustDistance = Geometry.distance(dx, dy, dadjust.getX(), dadjust.getY());
-            if (adjustDistance > getWiresManager().getDockingAcceptor().getHotspotSize())
+
+            if (adjustDistance < getWiresManager().getDockingAcceptor().getHotspotSize())
             {
                 dxy.setX(dadjust.getX());
                 dxy.setY(dadjust.getY());
@@ -216,8 +216,8 @@ public class WiresShapeControlImpl extends AbstractWiresBoundsConstraintControl 
                 adjust = false;
             }
         }
+        
         // Cache the current adjust point.
-
         m_adjust = dxy;
 
         parentPickerControl.onMoveAdjusted(m_adjust);


### PR DESCRIPTION
-Fixed docking offsets, when the path BB does not have a minX and min…Y of 0.
-The snaps adjustDistance was the wrong way around, which gave weird behaviour while dragging a docked item.
-For issue where PolyLine adjusts enhancement breaks OrthogonalLine, which does not impl the method and returns null.